### PR TITLE
fix(font_work): use working bmfont64.exe for BMFont generation

### DIFF
--- a/font_work/FontXnaBuilder.ps1
+++ b/font_work/FontXnaBuilder.ps1
@@ -191,7 +191,7 @@ function Generate-Font {
         
         $process = Start-Process -FilePath $BMFontExe `
             -ArgumentList "-c `"$configAbs`" -o `"$fontAbs`"" `
-            -Wait -PassThru -NoNewWindow -WorkingDirectory $ScriptDir
+            -Wait -PassThru -WorkingDirectory $ScriptDir
         
         if ($process.ExitCode -ne 0) {
             throw "BMFont 生成失败，退出代码: $($process.ExitCode)"

--- a/font_work/config.json
+++ b/font_work/config.json
@@ -1,6 +1,6 @@
 {
   "global": {
-    "bmfontExe": "./bmfont64.com",
+    "bmfontExe": "./bmfont64.exe",
     "xnaFontRebuilder": "./XnaFontRebuilder/bin/Release/net8.0/XnaFontRebuilder.dll",
     "sourceFont": "./ShangguRound-Bold.ttf",
     "fontInfoDir": "./FontInfo"


### PR DESCRIPTION
bmfont64.com is a 3584-byte 32-bit stub that produces no output, causing FontXnaBuilder.ps1 to fail at the BMFont step. Switch config.json bmfontExe to bmfont64.exe (the real 64-bit binary) and drop -NoNewWindow from Start-Process so the GUI binary's exit code can be read.

## Sourcery 摘要

错误修复：
- 通过选择可正常运行的 64 位 BMFont 可执行文件，并确保能够可靠地捕获其退出代码，修复 BMFont 生成问题。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Fix BMFont generation by selecting the functional 64-bit BMFont executable and allowing its exit code to be captured reliably.

</details>