### PR TITLE
fix(font_work): use absolute font path for BMFont config

### DIFF
--- a/font_work/FontXnaBuilder.ps1
+++ b/font_work/FontXnaBuilder.ps1
@@ -127,12 +127,13 @@ function Generate-ConfigFile {
     try {
         # 使用 --build-cfg-auto 命令生成配置文件
         # 从 XNA 二进制字体文件提取字符信息并生成 BMFont 配置
+        $absoluteFontPath = Join-Path $PWD ($SourceFont -replace '^\./', '')
         $cmdArgs = @(
             "`"$XnaFontRebuilder`""
             "--build-cfg-auto"
             "`"$($FontConfig.CharInfoFile)`""
             "`"$($FontConfig.ConfigFile)`""
-            "`"$SourceFont`""
+            "`"$absoluteFontPath`""
         )
 
         $cmd = "dotnet " + ($cmdArgs -join " ")
@@ -204,6 +205,10 @@ function Generate-Font {
         # 统计生成的图片
         $pngFiles = Get-ChildItem -Path $FontConfig.OutputDir -Filter "$($FontName)_*.png" -ErrorAction SilentlyContinue
         Write-Host "    ✓ 生成成功，纹理图片: $($pngFiles.Count) 张" -ForegroundColor Green
+        if ($pngFiles.Count -le 1) {
+            Write-Host "    ⚠ 警告: 只生成了 $($pngFiles.Count) 张纹理！BMFont 可能在当前环境无法正确渲染字体" -ForegroundColor Yellow
+            Write-Host "    ⚠ .fnt 大小: $((Get-Item $fontPath).Length) bytes (正常应为 1MB+)" -ForegroundColor Yellow
+        }
     }
     catch {
         Write-Host "    ✗ 失败: $_" -ForegroundColor Red


### PR DESCRIPTION
BMFont .bmfc config had relative fontFile path. On GitHub Actions headless environment, BMFont may not resolve relative paths correctly, falling back to system default font and generating only 1 texture sheet. Pass absolute font path to XnaFontRebuilder --build-cfg-auto. Add diagnostic warning when BMFont produces only 1 texture.

## Sourcery 摘要

确保 BMFont 生成在无头环境中使用预期的字体，并在输出似乎不完整时提供诊断信息。

错误修复：
- 生成 BMFont 配置文件时使用绝对字体路径，以确保无头环境能够正确解析预期的字体。
- 当字体生成产生不超过一个纹理图集时发出警告，并包含生成字体文件的大小以便进行诊断。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Ensure BMFont generation uses the intended font in headless environments and surface diagnostics when output appears incomplete.

Bug Fixes:
- Use an absolute font path when generating BMFont configuration files to ensure headless environments resolve the intended font correctly.
- Warn when font generation produces one or fewer texture sheets, including the generated font file size for diagnostics.

</details>