### PR TITLE
fix(font_work): patch .bmfc config to use absolute font path

### DIFF
--- a/font_work/FontXnaBuilder.ps1
+++ b/font_work/FontXnaBuilder.ps1
@@ -147,6 +147,14 @@ function Generate-ConfigFile {
             throw "未找到生成的配置文件"
         }
         
+        # 修复 .bmfc 中的字体路径为绝对路径（XnaFontRebuilder 会生成相对路径，BMFont 在 GitHub Actions 上可能无法解析）
+        $configAbsPath = Resolve-Path $FontConfig.ConfigFile
+        $configContent = Get-Content $configAbsPath -Raw
+        $absoluteFontPath = Join-Path $PWD ($SourceFont -replace '^\./', '')
+        $configContent = $configContent -replace 'fontFile=.*', "fontFile=$absoluteFontPath"
+        Set-Content -Path $configAbsPath -Value $configContent
+        Write-Host "    ✓ 已修复字体路径为绝对路径" -ForegroundColor Green
+        
         Write-Host "    ✓ 配置文件生成成功: $($FontConfig.ConfigFile)" -ForegroundColor Green
         return $true
     }


### PR DESCRIPTION
XnaFontRebuilder --build-cfg-auto ignores the absolute font path argument and always generates a relative fontFile in .bmfc. BMFont on GitHub Actions cannot resolve relative paths, falls back to system default font, and generates only 1 texture sheet. Now directly patches the generated .bmfc file to replace fontFile with an absolute path before BMFont runs.

## Sourcery 生成的摘要

错误修复：
- 确保生成的 BMFont 配置文件使用绝对字体路径，以便构建过程在 GitHub Actions 中解析预期的源字体。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Bug Fixes:
- Ensure generated BMFont configuration files use an absolute font path so builds resolve the intended source font in GitHub Actions.

</details>