### PR TITLE
fix: add -NoNewWindow and install VC++ redistributable

### DIFF
--- a/.github/workflows/build-and-localize.yml
+++ b/.github/workflows/build-and-localize.yml
@@ -23,6 +23,10 @@ jobs:
         cd font_work\XnaFontRebuilder
         dotnet build -c Release
     
+    - name: Install Visual C++ Redistributable
+      run: |
+        choco install vcruntime2015 vcruntime2019 --yes --force
+    
     - name: Generate fonts using FontXnaBuilder.ps1
       shell: pwsh
       run: |

--- a/font_work/FontXnaBuilder.ps1
+++ b/font_work/FontXnaBuilder.ps1
@@ -200,7 +200,7 @@ function Generate-Font {
         
         $process = Start-Process -FilePath $BMFontExe `
             -ArgumentList "-c `"$configAbs`" -o `"$fontAbs`"" `
-            -Wait -PassThru -WorkingDirectory $ScriptDir
+            -Wait -PassThru -NoNewWindow -WorkingDirectory $ScriptDir
         
         if ($process.ExitCode -ne 0) {
             throw "BMFont 生成失败，退出代码: $($process.ExitCode)"


### PR DESCRIPTION
BMFont is a GUI app. On headless GitHub Actions, Start-Process without -NoNewWindow may not correctly wait for font rendering. Add -NoNewWindow to force console mode. Also install Visual C++ 2015-2022 Redistributable which BMFont may require.

## Sourcery 总结

通过在当前控制台中运行 BMFont 并配置其 Visual C++ 运行时依赖项，提高自动字体生成的可靠性。

Bug 修复：
- 确保 BMFont 生成过程在无头 GitHub Actions 环境中可靠完成。
- 在工作流期间安装 BMFont 所需的 Visual C++ 2015–2022 可再发行组件依赖项。

构建：
- 更新 Windows 构建工作流，在生成字体之前配置 Visual C++ 运行时包。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Improve automated font generation reliability by running BMFont in the current console and provisioning its Visual C++ runtime dependencies.

Bug Fixes:
- Ensure BMFont generation completes reliably in headless GitHub Actions environments.
- Install the Visual C++ 2015–2022 redistributable dependencies required by BMFont during the workflow.

Build:
- Update the Windows build workflow to provision Visual C++ runtime packages before font generation.

</details>