### PR TITLE
fix(workflow): download VC++ Redistributable directly from Microsoft

### DIFF
--- a/.github/workflows/build-and-localize.yml
+++ b/.github/workflows/build-and-localize.yml
@@ -25,7 +25,8 @@ jobs:
     
     - name: Install Visual C++ Redistributable
       run: |
-        choco install visualstudio2019vcredist visualstudio2022vcredist --yes --force
+        Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.x64.exe" -OutFile "$env:TEMP\vc_redist.x64.exe"
+        Start-Process -FilePath "$env:TEMP\vc_redist.x64.exe" -ArgumentList "/install /quiet /norestart" -Wait
     
     - name: Generate fonts using FontXnaBuilder.ps1
       shell: pwsh


### PR DESCRIPTION
## Sourcery 摘要

在 Windows 构建工作流期间直接从 Microsoft 安装 Visual C++ Redistributable。

错误修复：
- 确保工作流通过直接从 Microsoft 下载当前的 x64 安装程序来安装 Visual C++ Redistributable。

构建：
- 更新 Windows 构建工作流，使用 Microsoft 的 VC++ Redistributable 安装程序替代 Chocolatey 软件包。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Install the Visual C++ Redistributable directly from Microsoft during the Windows build workflow.

Bug Fixes:
- Ensure the workflow installs the Visual C++ Redistributable by downloading the current x64 installer directly from Microsoft.

Build:
- Update the Windows build workflow to use Microsoft's VC++ Redistributable installer instead of Chocolatey packages.

</details>