### PR TITLE
fix(workflow): use windows-11 runner for BMFont font rendering

### DIFF
--- a/.github/workflows/build-and-localize.yml
+++ b/.github/workflows/build-and-localize.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build:
-    runs-on: windows-latest
+    runs-on: windows-11
     
     steps:
     - name: Checkout repository


### PR DESCRIPTION
BMFont is a GUI app that requires DirectWrite/Direct2D for font rendering. These APIs are not available on windows-latest (Windows Server 2022). Switch to windows-11 runner which has the Desktop Experience and necessary font rendering APIs.

## Sourcery 总结

在 Windows 11 上运行构建和本地化工作流，以支持 BMFont 字体渲染。

错误修复：
- 使用 Windows 11 runner 运行构建和本地化工作流，以确保 BMFont 渲染正常工作。

CI：
- 更新构建工作流，使其在 Windows 11 上运行，而不是使用默认的 Windows runner。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Run the build and localization workflow on Windows 11 to support BMFont font rendering.

Bug Fixes:
- Use a Windows 11 runner for the build and localization workflow so BMFont rendering works correctly.

CI:
- Update the build workflow to run on Windows 11 instead of the default Windows runner.

</details>