### PR TITLE
fix(workflow): enable Desktop Experience for font rendering APIs

### DIFF
--- a/.github/workflows/build-and-localize.yml
+++ b/.github/workflows/build-and-localize.yml
@@ -7,11 +7,19 @@ on:
 
 jobs:
   build:
-    runs-on: windows-11
+    runs-on: windows-latest
     
     steps:
     - name: Checkout repository
       uses: actions/checkout@v6
+    
+    - name: Enable Desktop Experience
+      shell: pwsh
+      run: |
+        # Windows Server 2022 默认是 Core 版，缺少 DirectWrite/Direct2D 字体渲染 API
+        # 启用 Desktop Experience 来安装这些 API
+        Install-WindowsFeature Desktop-Experience -IncludeAllSubFeature -ErrorAction SilentlyContinue
+        Install-WindowsFeature Server-Gui-Mgmt-Infra -IncludeAllSubFeature -ErrorAction SilentlyContinue
     
     - name: Setup .NET
       uses: actions/setup-dotnet@v5


### PR DESCRIPTION
Windows Server 2022 Core lacks DirectWrite/Direct2D needed by BMFont. Enable Desktop Experience feature to install these APIs.

## Sourcery 总结

在构建工作流中启用 Windows 字体渲染支持。

Bug 修复：
- 启用 Windows 构建工作流以使用桌面体验，从而提供 BMFont 所需的字体渲染 API。

构建：
- 更新工作流的 Windows 运行器配置，并添加所需桌面体验组件的安装步骤。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Enable Windows font-rendering support in the build workflow.

Bug Fixes:
- Enable the Windows build workflow to use the Desktop Experience so font-rendering APIs required by BMFont are available.

Build:
- Update the workflow’s Windows runner configuration and add installation of the required Desktop Experience components.

</details>